### PR TITLE
fix(kad-dht): fix DHT walk hang, CID key encoding, ADD_PROVIDER fire-and-forget

### DIFF
--- a/libp2p/kad_dht/kad_dht.py
+++ b/libp2p/kad_dht/kad_dht.py
@@ -1328,14 +1328,16 @@ class KadDHT(Service):
         """
         Reference to provider_store.provide for convenience.
         """
-        key_bytes = key.encode("utf-8")
+        from libp2p.bitswap.cid import cid_to_bytes, parse_cid
+        key_bytes = cid_to_bytes(parse_cid(key))
         return await self.provider_store.provide(key_bytes)
 
     async def find_providers(self, key: str, count: int = 20) -> list[PeerInfo]:
         """
         Reference to provider_store.find_providers for convenience.
         """
-        key_bytes = key.encode("utf-8")
+        from libp2p.bitswap.cid import cid_to_bytes, parse_cid
+        key_bytes = cid_to_bytes(parse_cid(key))
         return await self.provider_store.find_providers(key_bytes, count)
 
     def get_routing_table_size(self) -> int:

--- a/libp2p/kad_dht/peer_routing.py
+++ b/libp2p/kad_dht/peer_routing.py
@@ -245,9 +245,12 @@ class PeerRouting(IPeerRouting):
             # Admit at most ALPHA peers per round to preserve classic Kademlia
             # iterative refinement: after each small batch we re-sort with any
             # newly discovered peers before admitting the next batch.
-            peers_to_query = [p for p in closest_peers if p not in queried_peers][
-                :ALPHA
-            ]
+            # Exclude self - we can't query ourselves (Kubo does the same)
+            local_id = self.host.get_id()
+            peers_to_query = [
+                p for p in closest_peers
+                if p not in queried_peers and p != local_id
+            ][:ALPHA]
             if not peers_to_query:
                 logger.debug("No more unqueried peers available, ending lookup")
                 break

--- a/libp2p/kad_dht/provider_store.py
+++ b/libp2p/kad_dht/provider_store.py
@@ -222,19 +222,22 @@ class ProviderStore:
         """
         Send ADD_PROVIDER message to a specific peer.
 
+        Per the IPFS DHT spec, ADD_PROVIDER is fire-and-forget:
+        the receiver stores the provider record but does NOT send a response.
+        We send the message and close the stream.
+
         :param peer_id: The peer to send the message to
         :param key: The content key being provided
 
         Returns
         -------
         bool
-            True if the message was successfully sent and acknowledged
+            True if the message was successfully sent
 
         """
         stream = None
 
         try:
-            result = False
             # Open a stream to the peer
             stream = await self.host.new_stream(peer_id, [TProtocol(PROTOCOL_ID)])
 
@@ -265,50 +268,15 @@ class ProviderStore:
             await stream.write(varint.encode(len(proto_bytes)))
             await stream.write(proto_bytes)
             logger.debug(f"Sent ADD_PROVIDER to {peer_id} for key {key.hex()}")
-            # Read response length prefix
-            length_bytes = b""
-            while True:
-                logger.debug("Reading response length prefix in add provider")
-                b = await stream.read(1)
-                if not b:
-                    return False
-                length_bytes += b
-                if b[0] & 0x80 == 0:
-                    break
-
-            response_length = varint.decode_bytes(length_bytes)
-            # Read response data
-            response_bytes = b""
-            remaining = response_length
-            while remaining > 0:
-                chunk = await stream.read(remaining)
-                if not chunk:
-                    return False
-                response_bytes += chunk
-                remaining -= len(chunk)
-
-            # Parse response
-            response = Message()
-            response.ParseFromString(response_bytes)
-
-            if response.type == Message.MessageType.ADD_PROVIDER:
-                # Consume the sender's signed-peer-record if sent
-                if not maybe_consume_signed_record(response, self.host, peer_id):
-                    logger.error(
-                        "Received an invalid-signed-record, ignoring the response"
-                    )
-                    result = False
-                else:
-                    result = True
+            return True
 
         except Exception as e:
             logger.warning(f"Error sending ADD_PROVIDER to {peer_id}: {e}")
+            return False
 
         finally:
             if stream is not None:
                 await stream.close()
-
-        return result
 
     async def find_providers(self, key: bytes, count: int = 20) -> list[PeerInfo]:
         """


### PR DESCRIPTION
## Changes

### 1. Self-exclusion in DHT walk (`peer_routing.py`)
Exclude local peer from `peers_to_query` in the iterative walk. Previously, when the walk discovered our own ID from the remote peer, it would try to query ourselves, causing a hang. Kubo excludes self the same way.

**Result**: Walk completes in 1 round (1.5s) instead of hanging for 20 rounds.

### 2. CID key encoding (`kad_dht.py`)
`provide()` and `find_providers()` used `key.encode("utf-8")` which produced a 59-byte ASCII CID string instead of a 36-byte raw CID multihash. Fixed to use `cid_to_bytes(parse_cid(key))`.

### 3. ADD_PROVIDER fire-and-forget (`provider_store.py`)
Per the IPFS DHT spec, ADD_PROVIDER is fire-and-forget — the receiver stores the record but does NOT send a response. Removed the response wait that was causing 10s timeouts per peer.

## Testing
Verified with py-ipfs-lite ↔ Kubo (EC2) interop:
- Provide completes in ~1.5s (was hanging)
- Kubo can `cat` files provided by our node
- Walk logs show "1 rounds (1 queries), found 1 peers"